### PR TITLE
Lower required Android API to 9 and use Animal Sniffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .DS_Store
 out/
 gradle.properties
+*.iml

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,17 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id "com.jfrog.bintray" version "1.7.3"
+    id 'ru.vyarus.animalsniffer' version '1.4.3'
 }
+
+apply plugin: 'ru.vyarus.animalsniffer'
+dependencies {
+    signature "net.sf.androidscents.signature:android-api-level-9:2.3.1_r2@signature"
+}
+animalsniffer {
+    sourceSets = [sourceSets.main]
+}
+
 
 checkstyle {
     toolVersion = "8.1"

--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/BuildDecryptionInputStreamAPI.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/BuildDecryptionInputStreamAPI.java
@@ -3,9 +3,10 @@ package name.neuhalfen.projects.crypto.bouncycastle.openpgp;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.NoSuchProviderException;
-import java.time.Instant;
+import java.util.Date;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.decrypting.DecryptionStreamFactory;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.KeySelectionStrategy;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.Rfc4880KeySelectionStrategy;
@@ -25,8 +26,7 @@ public final class BuildDecryptionInputStreamAPI {
   @Nonnull
   private SignatureValidationStrategy signatureCheckingMode;
 
-  private KeySelectionStrategy keySelectionStrategy = new Rfc4880KeySelectionStrategy(
-      Instant.now());
+  private KeySelectionStrategy keySelectionStrategy = new Rfc4880KeySelectionStrategy(new Date());
 
   /**
    * Start building by passing in the keyring config.
@@ -50,12 +50,11 @@ public final class BuildDecryptionInputStreamAPI {
 
     ValidationWithKeySelectionStrategy() {
       super();
-      BuildDecryptionInputStreamAPI.this.keySelectionStrategy = new Rfc4880KeySelectionStrategy(
-          Instant.now());
+      BuildDecryptionInputStreamAPI.this.keySelectionStrategy = new Rfc4880KeySelectionStrategy(new Date());
     }
 
     public Validation setReferenceDateForKeyValidityTo(
-        Instant dateOfTimestampVerification) {
+        Date dateOfTimestampVerification) {
       if (dateOfTimestampVerification == null) {
         throw new IllegalArgumentException("dateOfTimestampVerification must not be null");
       }

--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/BuildEncryptionOutputStreamAPI.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/BuildEncryptionOutputStreamAPI.java
@@ -5,10 +5,11 @@ import java.io.OutputStream;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SignatureException;
-import java.time.Instant;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nullable;
+
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.algorithms.DefaultPGPAlgorithmSuites;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.algorithms.PGPAlgorithmSuite;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.encrypting.PGPEncryptingStream;
@@ -66,11 +67,11 @@ public final class BuildEncryptionOutputStreamAPI {
     private WithKeySelectionStrategy() {
       super();
       BuildEncryptionOutputStreamAPI.this.keySelectionStrategy = new Rfc4880KeySelectionStrategy(
-          Instant.now());
+          new Date());
     }
 
     public WithAlgorithmSuite setReferenceDateForKeyValidityTo(
-        Instant dateOfTimestampVerification) {
+        Date dateOfTimestampVerification) {
       if (dateOfTimestampVerification == null) {
         throw new IllegalArgumentException("dateOfTimestampVerification must not be null");
       }
@@ -87,7 +88,7 @@ public final class BuildEncryptionOutputStreamAPI {
       }
       BuildEncryptionOutputStreamAPI.this.keySelectionStrategy = strategy;
       LOGGER.trace("WithKeySelectionStrategy: override strategy to {}",
-          strategy.getClass().toGenericString());
+          strategy.getClass().getName());
       return new WithAlgorithmSuiteImpl();
     }
   }

--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/Rfc4880KeySelectionStrategy.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/Rfc4880KeySelectionStrategy.java
@@ -1,14 +1,12 @@
 package name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks;
 
 import java.io.IOException;
-import java.time.Instant;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
+
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.KeyringConfig;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPKeyFlags;
@@ -30,14 +28,14 @@ public class Rfc4880KeySelectionStrategy implements KeySelectionStrategy {
   private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory
       .getLogger(Rfc4880KeySelectionStrategy.class);
 
-  private final Instant dateOfTimestampVerification;
+  private final Date dateOfTimestampVerification;
 
   /**
    * The date used for key expiration date checks as "now".
    *
    * @return dateOfTimestampVerification
    */
-  protected Instant getDateOfTimestampVerification() {
+  protected Date getDateOfTimestampVerification() {
     return dateOfTimestampVerification;
   }
 
@@ -45,7 +43,7 @@ public class Rfc4880KeySelectionStrategy implements KeySelectionStrategy {
   /**
    * @param dateOfTimestampVerification The date used for key expiration date checks as "now".
    */
-  public Rfc4880KeySelectionStrategy(final Instant dateOfTimestampVerification) {
+  public Rfc4880KeySelectionStrategy(final Date dateOfTimestampVerification) {
     this.dateOfTimestampVerification = dateOfTimestampVerification;
   }
 
@@ -97,12 +95,17 @@ public class Rfc4880KeySelectionStrategy implements KeySelectionStrategy {
     final Set<PGPPublicKeyRing> publicKeyrings = this
         .publicKeyRingsForUid(PURPOSE.FOR_SIGNING, uid, keyringConfig);
 
-    return publicKeyrings.stream()
-        .flatMap(keyring -> StreamSupport.stream(keyring.spliterator(), false))
-        .filter(this::isVerificationKey)
-        .filter(this::isNotRevoked)
-        .filter(this::isNotExpired)
-        .collect(Collectors.toSet());
+    Set<PGPPublicKey> validKeys = new HashSet<>();
+    for (PGPPublicKeyRing p : publicKeyrings) {
+      Iterator<PGPPublicKey> keys = p.iterator();
+      while (keys.hasNext()) {
+        PGPPublicKey key = keys.next();
+        if (isVerificationKey(key) && isNotRevoked(key) && isNotExpired(key)) {
+          validKeys.add(key);
+        }
+      }
+    }
+    return validKeys;
   }
 
   @Nullable
@@ -116,51 +119,60 @@ public class Rfc4880KeySelectionStrategy implements KeySelectionStrategy {
 
     final PGPSecretKeyRingCollection secretKeyRings = keyringConfig.getSecretKeyRings();
 
+    PGPPublicKey publicKey = null;
     switch (purpose) {
       case FOR_SIGNING:
-        return publicKeyrings.stream()
-            .flatMap(keyring -> StreamSupport.stream(keyring.spliterator(), false))
-            .filter(this::isVerificationKey)
-            .filter(this::isNotRevoked)
-            .filter(this::isNotExpired)
-            .filter(hasPrivateKey(secretKeyRings))
-            .reduce((a, b) -> b)
-            .orElse(null);
+        for (PGPPublicKeyRing ring : publicKeyrings) {
+          Iterator<PGPPublicKey> iterator = ring.iterator();
+          while (iterator.hasNext()) {
+            PGPPublicKey key = iterator.next();
+            if (isVerificationKey(key) &&
+                    isNotRevoked(key) &&
+                    isNotExpired(key) &&
+                    hasPrivateKey(key, secretKeyRings)) {
+              publicKey = key;
+            }
+          }
+        }
+        return publicKey;
 
       case FOR_ENCRYPTION:
-        return publicKeyrings.stream()
-            .flatMap(keyring -> StreamSupport.stream(keyring.spliterator(), false))
-            .filter(this::isEncryptionKey)
-            .filter(this::isNotRevoked)
-            .filter(this::isNotExpired)
-            .reduce((a, b) -> b)
-            .orElse(null);
+        for (PGPPublicKeyRing ring : publicKeyrings) {
+          Iterator<PGPPublicKey> iterator = ring.iterator();
+          while (iterator.hasNext()) {
+            PGPPublicKey key = iterator.next();
+            if (isEncryptionKey(key) &&
+                    isNotRevoked(key) &&
+                    isNotExpired(key)) {
+              publicKey = key;
+            }
+          }
+        }
+        return publicKey;
 
       default:
         return null;
     }
   }
 
+  protected boolean hasPrivateKey(PGPPublicKey pubKey, PGPSecretKeyRingCollection secretKeyRings) {
+    boolean result = false;
+    try {
+      final boolean hasPrivateKey = secretKeyRings.contains(pubKey.getKeyID());
 
-  protected Predicate<PGPPublicKey> hasPrivateKey(final PGPSecretKeyRingCollection secretKeyRings) {
-    return pubKey -> {
-      try {
-        final boolean hasPrivateKey = secretKeyRings.contains(pubKey.getKeyID());
-
-        if (!hasPrivateKey) {
-          LOGGER.trace("Skipping pubkey {} (no private key found)",
-              Long.toHexString(pubKey.getKeyID()));
-        }
-
-        return hasPrivateKey;
-      } catch (PGPException e) {
-        // ignore this for filtering
-        LOGGER.debug("Failed to test for private key for pubkey " + pubKey.getKeyID());
-        return false;
+      if (!hasPrivateKey) {
+        LOGGER.trace("Skipping pubkey {} (no private key found)",
+                Long.toHexString(pubKey.getKeyID()));
       }
-    };
-  }
 
+      result = hasPrivateKey;
+    } catch (PGPException e) {
+      // ignore this for filtering
+      LOGGER.debug("Failed to test for private key for pubkey " + pubKey.getKeyID());
+    }
+
+    return result;
+  }
 
   protected boolean isNotMasterKey(PGPPublicKey pubKey) {
     return !pubKey.isMasterKey();
@@ -179,10 +191,9 @@ public class Rfc4880KeySelectionStrategy implements KeySelectionStrategy {
     final boolean isExpired;
 
     if (hasExpiryDate) {
-      final Instant expiryDate = pubKey.getCreationTime().toInstant()
-          .plusSeconds(pubKey.getValidSeconds());
+      final Date expiryDate = new Date(pubKey.getCreationTime().getTime() + 1000L * pubKey.getValidSeconds());
       isExpired = expiryDate
-          .isBefore(getDateOfTimestampVerification());
+          .before(getDateOfTimestampVerification());
 
       if (isExpired) {
         LOGGER.trace("Skipping pubkey {} (expired since {})",

--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/keyrings/FileBasedKeyringConfig.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/keyrings/FileBasedKeyringConfig.java
@@ -1,10 +1,11 @@
 package name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 import javax.annotation.Nonnull;
+
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.KeyringConfigCallback;
 
 /**
@@ -27,12 +28,12 @@ final class FileBasedKeyringConfig extends AbstractDefaultKeyringConfig {
   @Nonnull
   @Override
   protected InputStream getPublicKeyRingStream() throws IOException {
-    return Files.newInputStream(publicKeyring.toPath());
+    return new FileInputStream(publicKeyring);
   }
 
   @Nonnull
   @Override
   protected InputStream getSecretKeyRingStream() throws IOException {
-    return Files.newInputStream(secretKeyring.toPath());
+    return new FileInputStream(secretKeyring);
   }
 }

--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/keyrings/InMemoryKeyring.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/keyrings/InMemoryKeyring.java
@@ -54,13 +54,21 @@ public final class InMemoryKeyring implements KeyringConfig {
       throw new IllegalArgumentException("encodedPublicKey must not be null");
     }
 
-    try (
-        final InputStream raw = new ByteArrayInputStream(encodedPublicKey);
-        final InputStream decoded = org.bouncycastle.openpgp.PGPUtil.getDecoderStream(raw)
-    ) {
+    InputStream raw = null;
+    InputStream decoded = null;
+    try {
+      raw = new ByteArrayInputStream(encodedPublicKey);
+      decoded = org.bouncycastle.openpgp.PGPUtil.getDecoderStream(raw);
       PGPPublicKeyRing pgpPub = new PGPPublicKeyRing(decoded, getKeyFingerPrintCalculator());
       this.publicKeyRings = PGPPublicKeyRingCollection
-          .addPublicKeyRing(this.publicKeyRings, pgpPub);
+              .addPublicKeyRing(this.publicKeyRings, pgpPub);
+    }
+    catch (IOException e) {
+      if (decoded != null) {
+        decoded.close();
+      }
+      raw.close();
+      throw e;
     }
   }
 
@@ -82,15 +90,22 @@ public final class InMemoryKeyring implements KeyringConfig {
       throw new IllegalArgumentException("encodedPrivateKey must not be null");
     }
 
-    try (
-        final InputStream raw = new ByteArrayInputStream(encodedPrivateKey);
-        final InputStream decoded = org.bouncycastle.openpgp.PGPUtil
-            .getDecoderStream(raw)
-    ) {
+    InputStream raw = null;
+    InputStream decoded = null;
+    try {
+      raw = new ByteArrayInputStream(encodedPrivateKey);
+      decoded = org.bouncycastle.openpgp.PGPUtil
+              .getDecoderStream(raw);
       PGPSecretKeyRing pgpPRivate = new PGPSecretKeyRing(decoded, getKeyFingerPrintCalculator());
       this.secretKeyRings =
-          PGPSecretKeyRingCollection
-              .addSecretKeyRing(this.secretKeyRings, pgpPRivate);
+              PGPSecretKeyRingCollection
+                      .addSecretKeyRing(this.secretKeyRings, pgpPRivate);
+    } catch (IOException e) {
+      if (decoded != null) {
+        decoded.close();
+      }
+      raw.close();
+      throw e;
     }
   }
 

--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/reencryption/ExplodeAndReencrypt.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/reencryption/ExplodeAndReencrypt.java
@@ -62,11 +62,9 @@ final class ExplodeAndReencrypt {
         numFiles++;
 
         LOGGER.debug("found file '{}'", entry.getName());
-
-        try (
-            final OutputStream outputStream = entityHandlingStrategy
-                .createOutputStream(sanitizedFileName)
-        ) {
+        OutputStream outputStream = null;
+        try {
+          outputStream = entityHandlingStrategy.createOutputStream(sanitizedFileName);
           if (outputStream == null) {
             LOGGER.trace("Ignore {}", entry.getName());
           } else {
@@ -74,6 +72,10 @@ final class ExplodeAndReencrypt {
             Streams.pipeAll(zis, encryptedSmallFromZIP);
             encryptedSmallFromZIP.flush();
             encryptedSmallFromZIP.close();
+          }
+        } finally {
+          if (outputStream != null) {
+            outputStream.close();
           }
         }
       }

--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/validation/SignatureValidationStrategies.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/validation/SignatureValidationStrategies.java
@@ -6,10 +6,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
+
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.KeySelectionStrategy;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.KeyringConfig;
 import org.bouncycastle.openpgp.PGPException;
@@ -134,8 +135,10 @@ public final class SignatureValidationStrategies {
         throw new PGPException("Could not find public-key for userid '" + userId + "'");
       }
 
-      Set<Long> keysForUid = availableKeys.stream().map(key -> key.getKeyID())
-          .collect(Collectors.toSet());
+      Set<Long> keysForUid = new HashSet<>();
+      for (PGPPublicKey p : availableKeys) {
+        keysForUid.add(p.getKeyID());
+      }
 
       keyIdsByUid.put(userId, keysForUid);
     }

--- a/src/main/java/name/neuhalfen/projects/crypto/symmetric/keygeneration/DerivedKeyGenerator.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/symmetric/keygeneration/DerivedKeyGenerator.java
@@ -1,13 +1,11 @@
 package name.neuhalfen.projects.crypto.symmetric.keygeneration;
 
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
+import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import javax.annotation.Nullable;
+
 import name.neuhalfen.projects.crypto.symmetric.keygeneration.impl.derivation.KeyDerivationFunction;
 
 public class DerivedKeyGenerator {
@@ -110,9 +108,10 @@ public class DerivedKeyGenerator {
    */
   @SuppressWarnings("PMD.LawOfDemeter")
   private byte[] byteRepresentationOf(String identifier) {
-    final ByteBuffer buffer = UTF_8.encode(CharBuffer.wrap(identifier));
-    final byte[] identifierByteRepresentation = new byte[buffer.limit()];
-    buffer.get(identifierByteRepresentation);
-    return identifierByteRepresentation;
+    return identifier.getBytes(Charset.forName("UTF-8"));
+//    final ByteBuffer buffer = UTF_8.encode(CharBuffer.wrap(identifier));
+//    final byte[] identifierByteRepresentation = new byte[buffer.limit()];
+//    buffer.get(identifierByteRepresentation);
+//    return identifierByteRepresentation;
   }
 }

--- a/src/main/java/name/neuhalfen/projects/crypto/symmetric/keygeneration/impl/stretching/MasterKeyFromPasswordDerivation.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/symmetric/keygeneration/impl/stretching/MasterKeyFromPasswordDerivation.java
@@ -1,9 +1,7 @@
 package name.neuhalfen.projects.crypto.symmetric.keygeneration.impl.stretching;
 
 
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
 
 public class MasterKeyFromPasswordDerivation {
@@ -49,9 +47,10 @@ public class MasterKeyFromPasswordDerivation {
    */
   @SuppressWarnings("PMD.LawOfDemeter")
   private byte[] byteRepresentationOf(String identifier) {
-    final ByteBuffer buffer = StandardCharsets.UTF_8.encode(CharBuffer.wrap(identifier));
-    final byte[] identifierByteRepresentation = new byte[buffer.limit()];
-    buffer.get(identifierByteRepresentation);
-    return identifierByteRepresentation;
+    return identifier.getBytes(Charset.forName("UTF-8"));
+    // final ByteBuffer buffer = StandardCharsets.UTF_8.encode(CharBuffer.wrap(identifier));
+    // final byte[] identifierByteRepresentation = new byte[buffer.limit()];
+    // buffer.get(identifierByteRepresentation);
+    // return identifierByteRepresentation;
   }
 }

--- a/src/main/java/name/neuhalfen/projects/crypto/symmetric/keygeneration/impl/stretching/SCryptKeyStretching.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/symmetric/keygeneration/impl/stretching/SCryptKeyStretching.java
@@ -1,7 +1,7 @@
 package name.neuhalfen.projects.crypto.symmetric.keygeneration.impl.stretching;
 
 import java.io.Serializable;
-import java.util.Objects;
+
 import org.bouncycastle.crypto.generators.SCrypt;
 
 
@@ -105,7 +105,7 @@ public class SCryptKeyStretching implements KeyStretching {
 
     @Override
     public int hashCode() {
-      return Objects.hash(N, r, p);
+      return 31 * N + 17 * r + p;
     }
 
     @Override

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/encrypting/EncryptionConfig.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/encrypting/EncryptionConfig.java
@@ -3,6 +3,7 @@ package name.neuhalfen.projects.crypto.bouncycastle.openpgp.encrypting;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.KeySelectionStrategy;
@@ -27,7 +28,7 @@ public class EncryptionConfig {
   private final KeyringConfig keyringConfig;
 
   private final KeySelectionStrategy keySelectionStrategy = new Rfc4880KeySelectionStrategy(
-      Instant.MAX);
+          new Date(Long.MAX_VALUE));
 
   public EncryptionConfig(String signatureSecretKeyId,
       String encryptionPublicKeyId,

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/RFC4880KeySelectionStrategyTest.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/RFC4880KeySelectionStrategyTest.java
@@ -9,9 +9,10 @@ import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 import java.security.Security;
-import java.time.Instant;
+import java.util.Date;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.KeySelectionStrategy.PURPOSE;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.KeyringConfig;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.testtooling.Configs;
@@ -245,7 +246,7 @@ public class RFC4880KeySelectionStrategyTest {
     final KeyringConfig keyringConfig = RFC4880TestKeyringsMasterKeyAsSigningKey
         .publicAndPrivateKeyKeyringConfig();
 
-    final KeySelectionStrategy keySelectionStrategy = new Rfc4880KeySelectionStrategy(Instant.MAX);
+    final KeySelectionStrategy keySelectionStrategy = new Rfc4880KeySelectionStrategy(new Date(Long.MAX_VALUE));
 
     final PGPPublicKey signingPublicKey = keySelectionStrategy
         .selectPublicKey(PURPOSE.FOR_SIGNING, RFC4880TestKeyringsMasterKeyAsSigningKey.UID_EMAIL,

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/RFC4880TestKeyringsDedicatedSigningKey.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/RFC4880TestKeyringsDedicatedSigningKey.java
@@ -1,8 +1,8 @@
 package name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.ZonedDateTime;
+import java.util.Date;
+
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.InMemoryKeyring;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.KeyringConfig;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.KeyringConfigs;
@@ -32,23 +32,22 @@ ssb  rsa2048/0x83063C3DA3814052
 
   public final static String UID_EMAIL = "rfc4880@example.org";
 
-  public final static Instant EXPIRED_KEY_CREATION_TIME = ZonedDateTime
-      .parse("2018-03-25T10:55:31Z").toInstant();
+  public final static Date EXPIRED_KEY_CREATION_TIME =
+          new Date(1521975331000L);
 
-  public final static Instant EXPIRED_KEY_EXPIRATION_DATE = ZonedDateTime
-      .parse("2018-03-26T10:56:21Z")
-      .toInstant();
+  public final static Date EXPIRED_KEY_EXPIRATION_DATE =
+          new Date(1522061781000L);
 
   /**
    * Key SIGNATURE_KEY_EXPIRED is no longer valid here.
    */
-  public final static Instant SIGNATURE_KEY_GUARANTEED_EXPIRED_AT = EXPIRED_KEY_EXPIRATION_DATE
-      .plusSeconds(1);
+  public final static Date SIGNATURE_KEY_GUARANTEED_EXPIRED_AT =
+          new Date(EXPIRED_KEY_EXPIRATION_DATE.getTime() + 1000L);
   /**
    * Key SIGNATURE_KEY_EXPIRED is still valid here.
    */
-  public final static Instant SIGNATURE_KEY_GUARANTEED_VALID_AT = EXPIRED_KEY_EXPIRATION_DATE
-      .minusSeconds(1);
+  public final static Date SIGNATURE_KEY_GUARANTEED_VALID_AT =
+          new Date(EXPIRED_KEY_EXPIRATION_DATE.getTime() - 1000L);
 
   public final static long MASTER_KEY_ID = Long.parseUnsignedLong("F8BEA74E37D9F45D", 16);
   public final static long ENCRYPTION_KEY = Long.parseUnsignedLong("47377FEDD16C26B3", 16);

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/RFC4880TestKeyringsDedicatedSigningKeySanityTest.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/RFC4880TestKeyringsDedicatedSigningKeySanityTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.security.Security;
+import java.util.Date;
+
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.KeyringConfig;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openpgp.PGPException;
@@ -99,7 +101,7 @@ public class RFC4880TestKeyringsDedicatedSigningKeySanityTest {
     assertNotNull("Expired Signature key exists", publicKey);
 
     assertEquals("Expired key has correct creation date set", EXPIRED_KEY_CREATION_TIME,
-        publicKey.getCreationTime().toInstant());
+        new Date(publicKey.getCreationTime().getTime()));
     assertEquals("Expired key has correct expiry time set", 86450, publicKey.getValidSeconds());
   }
 

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/roundtrip/EncryptionDecryptionRoundtripIntegrationTest.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/roundtrip/EncryptionDecryptionRoundtripIntegrationTest.java
@@ -15,6 +15,8 @@ import java.security.NoSuchProviderException;
 import java.security.Security;
 import java.security.SignatureException;
 import java.time.Instant;
+import java.util.Date;
+
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.BouncyGPG;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.algorithms.DefaultPGPAlgorithmSuites;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.algorithms.PGPAlgorithmSuite;
@@ -327,7 +329,7 @@ public class EncryptionDecryptionRoundtripIntegrationTest {
     final OutputStream outputStream = BouncyGPG
         .encryptToStream()
         .withConfig(Configs.keyringConfigFromFilesForSender())
-        .setReferenceDateForKeyValidityTo(Instant.MAX)
+        .setReferenceDateForKeyValidityTo(new Date(Long.MAX_VALUE))
         .withAlgorithms(algorithmSuite)
         .toRecipient("recipient@example.com")
         .andSignWith("sender@example.com")
@@ -463,7 +465,7 @@ public class EncryptionDecryptionRoundtripIntegrationTest {
     final OutputStream outputStream = BouncyGPG
         .encryptToStream()
         .withConfig(Configs.keyringConfigFromResourceForSender())
-        .setReferenceDateForKeyValidityTo(Instant.MAX)
+        .setReferenceDateForKeyValidityTo(new Date(Long.MAX_VALUE))
         .withAlgorithms(algorithmSuite)
         .toRecipients("sender@example.com", "recipient@example.com")
         .andSignWith("sender@example.com")

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/tests_for_issues/Issue16Test.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/tests_for_issues/Issue16Test.java
@@ -15,6 +15,8 @@ import java.security.NoSuchProviderException;
 import java.security.Security;
 import java.security.SignatureException;
 import java.time.Instant;
+import java.util.Date;
+
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.BouncyGPG;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.KeyringConfigCallbacks;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.RFC4880TestKeyringsDedicatedSigningKey;
@@ -55,7 +57,7 @@ public class Issue16Test {
     encryptToStdout(config,
        recipient,
         signer,
-        Instant.now());
+        new Date());
   }
 
 
@@ -78,12 +80,12 @@ public class Issue16Test {
     encryptToStdout(RFC4880TestKeyringsMasterKeyAsSigningKey.publicAndPrivateKeyKeyringConfig(),
         RFC4880TestKeyringsMasterKeyAsSigningKey.UID_EMAIL,
         RFC4880TestKeyringsMasterKeyAsSigningKey.UID_EMAIL,
-        Instant.MAX);
+        new Date(Long.MAX_VALUE));
   }
 
   void encryptToStdout(final KeyringConfig config, final String recipientUid,
       final String signingUid,
-      final Instant dateOfTimestampVerification)
+      final Date dateOfTimestampVerification)
       throws IOException, PGPException, NoSuchAlgorithmException, NoSuchProviderException, SignatureException {
     final byte[] expectedPlaintext = ExampleMessages.IMPORTANT_QUOTE_TEXT.getBytes("US-ASCII");
 
@@ -146,14 +148,14 @@ public class Issue16Test {
         RFC4880TestKeyringsMasterKeyAsSigningKey.publicAndPrivateKeyKeyringConfig(),
         RFC4880TestKeyringsMasterKeyAsSigningKey.UID_EMAIL,
         RFC4880TestKeyringsMasterKeyAsSigningKey.UID_EMAIL,
-        Instant.MAX,
+        new Date(Long.MAX_VALUE),
         RFC4880TestKeyringsMasterKeyAsSigningKey.MASTER_KEY_ID);
   }
 
 
   private void signAtDateAndValidateExpectedKey(final KeyringConfig config,
       final String recipientUid,
-      final String signingUid, final Instant dateOfTimestampVerification,
+      final String signingUid, final Date dateOfTimestampVerification,
       long expectedSignatureKey)
       throws IOException, PGPException, NoSuchAlgorithmException, SignatureException, NoSuchProviderException {
     final byte[] expectedPlaintext = ExampleMessages.IMPORTANT_QUOTE_TEXT.getBytes("US-ASCII");


### PR DESCRIPTION
Hi!
This PR removes the usage of some newer Java features like stream semantics in order to allow the library to be used in Android applications targeting API level 9 and above.
I hope I didn't break anything, but the test cases (which I had to alter as well) are all passing.

I created this PR as I'm participating in this years Google Summer of Code. As part of my project I want to utilize this library to implement [XEP-0373](https://xmpp.org/extensions/xep-0374.html) and [XEP-0374](https://xmpp.org/extensions/xep-0374.html) (OpenPGP for XMPP) for the XMPP client library Smack.

I appreciate any feedback :)