### PR TITLE
Add support to search for the whole UID instead of e-mail only.

### DIFF
--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/BuildEncryptionOutputStreamAPI.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/BuildEncryptionOutputStreamAPI.java
@@ -12,6 +12,7 @@ import javax.annotation.Nullable;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.algorithms.DefaultPGPAlgorithmSuites;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.algorithms.PGPAlgorithmSuite;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.encrypting.PGPEncryptingStream;
+import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.ByEMailKeySelectionStrategy;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.KeySelectionStrategy;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.KeySelectionStrategy.PURPOSE;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.Rfc4880KeySelectionStrategy;
@@ -21,17 +22,24 @@ import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPSecretKey;
 
 
-@SuppressWarnings({"PMD.AtLeastOneConstructor", "PMD.AccessorMethodGeneration", "PMD.LawOfDemeter"})
+@SuppressWarnings({"PMD.GodClass","PMD.AtLeastOneConstructor",
+    "PMD.AccessorMethodGeneration", "PMD.LawOfDemeter","Checkstyle.AbbreviationAsWordInName"})
 public final class BuildEncryptionOutputStreamAPI {
 
   private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory
       .getLogger(BuildEncryptionOutputStreamAPI.class);
 
+  @SuppressWarnings({"PMD.ImmutableField"})
+  private WithKeySelectionStrategy keySelectionStrategyBuilder;
+
+  /*
+   * lazily populated by getKeySelectionStrategy()
+   */
+  private KeySelectionStrategy keySelectionStrategy;
+
   private OutputStream sinkForEncryptedData;
   private KeyringConfig encryptionConfig;
   private PGPAlgorithmSuite algorithmSuite;
-
-  private KeySelectionStrategy keySelectionStrategy;
 
   @Nullable
   private String signWith;
@@ -63,32 +71,99 @@ public final class BuildEncryptionOutputStreamAPI {
 
   public final class WithKeySelectionStrategy extends WithAlgorithmSuiteImpl {
 
+    @Nullable
+    private Instant dateOfTimestampVerification;
+    @Nullable
+    private Boolean selectUidByEMailOnly = null;
+    private final static boolean SELECT_UID_BY_E_MAIL_ONLY_DEFAULT = true;
+    @Nullable
+    private KeySelectionStrategy keySelectionStrategy = null;
+
     private WithKeySelectionStrategy() {
       super();
-      BuildEncryptionOutputStreamAPI.this.keySelectionStrategy = new Rfc4880KeySelectionStrategy(
-          Instant.now());
+      BuildEncryptionOutputStreamAPI.this.keySelectionStrategyBuilder = this;
     }
 
+    public WithKeySelectionStrategy selectUidByAnyUidPart() {
+      if (keySelectionStrategy != null) {
+        throw new IllegalStateException(
+            "selectUidByAnyUidPart/setReferenceDateForKeyValidityTo cannot be used together "+
+                "with 'withKeySelectionStrategy' ");
+      }
+      selectUidByEMailOnly = false;
+      return this;
+    }
+
+    /**
+     * In order to determine key validity a reference point in time for "now" is needed.
+     * The default value is "Instant.now()". If this needs to be overridden, pass the value
+     * here. To effectively disable time based key verification pass Instant.MAX (NOT recommended)
+     *
+     * This is not possible in combination with #withKeySelectionStrategy.
+     *
+     * @param dateOfTimestampVerification reference point in time
+     * @return next step in build
+     */
     public WithAlgorithmSuite setReferenceDateForKeyValidityTo(
         Instant dateOfTimestampVerification) {
+      if (keySelectionStrategy != null) {
+        throw new IllegalStateException(
+            "selectUidByAnyUidPart/setReferenceDateForKeyValidityTo cannot be used together "+
+                "with 'withKeySelectionStrategy' ");
+      }
       if (dateOfTimestampVerification == null) {
         throw new IllegalArgumentException("dateOfTimestampVerification must not be null");
       }
-      BuildEncryptionOutputStreamAPI.this.keySelectionStrategy = new Rfc4880KeySelectionStrategy(
-          dateOfTimestampVerification);
+      this.dateOfTimestampVerification = dateOfTimestampVerification;
       LOGGER.trace("WithKeySelectionStrategy: setReferenceDateForKeyValidityTo {}",
           dateOfTimestampVerification);
-      return new WithAlgorithmSuiteImpl();
+      return this;
     }
 
+    /**
+     * The default strategy to search for keys is to *just* search for the email address (the part
+     * between &lt; and &gt;).
+     *
+     * Set this flag to search for any part in the user id.
+     * @param strategy instance to use
+     * @return  next build step
+     */
     public WithAlgorithmSuite withKeySelectionStrategy(final KeySelectionStrategy strategy) {
       if (strategy == null) {
         throw new IllegalArgumentException("strategy must not be null");
       }
-      BuildEncryptionOutputStreamAPI.this.keySelectionStrategy = strategy;
+      if (selectUidByEMailOnly != null || dateOfTimestampVerification != null) {
+        throw new IllegalStateException(
+            "selectUidByAnyUidPart/setReferenceDateForKeyValidityTo cannot be used together"+
+                " with 'withKeySelectionStrategy' ");
+      }
+      this.keySelectionStrategy = strategy;
       LOGGER.trace("WithKeySelectionStrategy: override strategy to {}",
           strategy.getClass().toGenericString());
-      return new WithAlgorithmSuiteImpl();
+      return this;
+    }
+
+
+    // Duplicate of BuildDecryptionInputStreamAPI
+    @SuppressWarnings({"PMD.OnlyOneReturn"})
+    private KeySelectionStrategy buildKeySelectionStrategy() {
+      final boolean hasExistingStrategy = this.keySelectionStrategy != null;
+      if (hasExistingStrategy) {
+        return this.keySelectionStrategy;
+      } else {
+        if (this.selectUidByEMailOnly == null) {
+          this.selectUidByEMailOnly = SELECT_UID_BY_E_MAIL_ONLY_DEFAULT;
+        }
+        if (this.dateOfTimestampVerification == null) {
+          this.dateOfTimestampVerification = Instant.now();
+        }
+
+        if (this.selectUidByEMailOnly) {
+          return new ByEMailKeySelectionStrategy(this.dateOfTimestampVerification);
+        } else {
+          return new Rfc4880KeySelectionStrategy(this.dateOfTimestampVerification);
+        }
+      }
     }
   }
 
@@ -171,7 +246,7 @@ public final class BuildEncryptionOutputStreamAPI {
           throw new IllegalArgumentException("recipient must be a string");
         }
         try {
-          final PGPPublicKey recipientEncryptionKey = keySelectionStrategy
+          final PGPPublicKey recipientEncryptionKey = getKeySelectionStrategy()
               .selectPublicKey(PURPOSE.FOR_ENCRYPTION, recipient, encryptionConfig);
 
           if (recipientEncryptionKey == null) {
@@ -218,7 +293,7 @@ public final class BuildEncryptionOutputStreamAPI {
                 "encryptionConfig.getSecretKeyRings() must not be null");
           }
 
-          final PGPPublicKey signingKeyPubKey = keySelectionStrategy
+          final PGPPublicKey signingKeyPubKey = getKeySelectionStrategy()
               .selectPublicKey(PURPOSE.FOR_SIGNING, userId, encryptionConfig);
 
           if (signingKeyPubKey == null) {
@@ -272,7 +347,7 @@ public final class BuildEncryptionOutputStreamAPI {
                   BuildEncryptionOutputStreamAPI.this.algorithmSuite,
                   BuildEncryptionOutputStreamAPI.this.signWith,
                   BuildEncryptionOutputStreamAPI.this.sinkForEncryptedData,
-                  BuildEncryptionOutputStreamAPI.this.keySelectionStrategy,
+                  getKeySelectionStrategy(),
                   BuildEncryptionOutputStreamAPI.this.armorOutput,
                   BuildEncryptionOutputStreamAPI.this.recipients);
               return outputStream;
@@ -282,5 +357,13 @@ public final class BuildEncryptionOutputStreamAPI {
         }
       }
     }
+  }
+
+  private KeySelectionStrategy getKeySelectionStrategy() {
+    if (this.keySelectionStrategy == null) {
+      this.keySelectionStrategy = this.keySelectionStrategyBuilder
+          .buildKeySelectionStrategy();
+    }
+    return this.keySelectionStrategy;
   }
 }

--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/ByEMailKeySelectionStrategy.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/ByEMailKeySelectionStrategy.java
@@ -1,0 +1,76 @@
+package name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.KeyringConfig;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPPublicKeyRing;
+
+/**
+ * This implements the key selection strategy for BouncyGPG and selects keys based on
+ * email addresses.
+ *
+ * For this it wraps the given addresses in &lt;/&gt;.
+ *
+ * https://tools.ietf.org/html/rfc4880#section-5.2.3.21
+ */
+public class ByEMailKeySelectionStrategy extends Rfc4880KeySelectionStrategy implements
+    KeySelectionStrategy {
+
+  /**
+   * @param dateOfTimestampVerification The date used for key expiration date checks as "now".
+   */
+  public ByEMailKeySelectionStrategy(final Instant dateOfTimestampVerification) {
+    super(dateOfTimestampVerification, true, true);
+  }
+
+  /**
+   * Return all keyrings that ARE valid keys for the given uid.
+   *
+   * If the uid does not already include '&lt;...&gt;' then wrap it in "&lt;uid&gt;"
+   * to filter for e-mails.  E.g. "peter@example.com" will be converted to
+   * "&lt;peter@example.com&gt;" but "Klaus &lt;klaus@example.com&gt;" or
+   * "&lt;klaus@example.com&gt;" will be leaved untouched.
+   *
+   * @param uid the userid as passed by upstream.
+   * @param keyringConfig the keyring config
+   * @param purpose what is the requested key to be used for
+   *
+   * @return Set with keyrings, never null.
+   *
+   * @throws PGPException Something with BouncyCastle went wrong
+   * @throws IOException IO is dangerous
+   */
+  @SuppressWarnings({"PMD.LawOfDemeter"})
+  protected Set<PGPPublicKeyRing> publicKeyRingsForUid(final PURPOSE purpose, final String uid,
+      KeyringConfig keyringConfig)
+      throws IOException, PGPException {
+
+    final Set<PGPPublicKeyRing> keyringsForUid = new HashSet<>();
+
+    final String uidQuery;
+    final boolean uidAlreadyInBrackets = uid.matches(".*<.*>.*");
+    if (uidAlreadyInBrackets) {
+      uidQuery = uid;
+    } else {
+      uidQuery = "<" + uid + ">";
+    }
+
+    final Iterator<PGPPublicKeyRing> keyRings = keyringConfig.getPublicKeyRings()
+        .getKeyRings(uidQuery, true, true);
+
+    while (keyRings.hasNext()) {
+      keyringsForUid.add(keyRings.next());
+    }
+
+    return keyringsForUid;
+  }
+
+
+}
+
+
+

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/KeysTestHelper.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/KeysTestHelper.java
@@ -1,0 +1,34 @@
+package name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Iterator;
+import org.bouncycastle.openpgp.PGPPublicKey;
+
+public class KeysTestHelper {
+
+  public static void assertIsCorrectPublicKey(final long expectedKeyId, final PGPPublicKey actual) {
+    assertNotNull("A public key is expected but is not delivered", actual);
+
+    assertEquals(String.format("A specific key Id is expected. Actual: %s", formatKey(actual)),
+        expectedKeyId, actual.getKeyID());
+  }
+
+  public static String formatKey(final PGPPublicKey key) {
+    if (key == null) {
+      return "<null>";
+    }
+
+    StringBuilder b = new StringBuilder("{");
+    b.append("id: 0x").append(Long.toHexString(key.getKeyID())).append(", userIds: [");
+
+    final Iterator<String> userIDs = key.getUserIDs();
+    while (userIDs.hasNext()) {
+      b.append("'").append( userIDs.next()).append("', ");
+    }
+    b.append("]}");
+    return b.toString();
+
+  }
+}

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/ByEMailKeySelectionStrategyTest.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/ByEMailKeySelectionStrategyTest.java
@@ -1,0 +1,84 @@
+package name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks;
+
+import static name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.KeysTestHelper.assertIsCorrectPublicKey;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import java.security.Security;
+import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.KeySelectionStrategy.PURPOSE;
+import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.KeyringConfig;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openpgp.PGPException;
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * Test for compliance with https://tools.ietf.org/html/rfc4880
+ * when selecting keys.
+ *
+ * Selection is done for E-Mails only
+ */
+public class ByEMailKeySelectionStrategyTest {
+
+
+  final KeyringConfig keyringConfig = RFC4880TestKeyringsDedicatedSigningKey
+      .publicAndPrivateKeyKeyringConfig();
+
+  @Before
+  public void before() {
+    if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+      Security.addProvider(new BouncyCastleProvider());
+    }
+  }
+
+
+  @Test
+  public void searchForEMailUnquoted_keyExists_keyIsFound()
+      throws IOException, PGPException {
+
+    // searching for a key based on an unquoted (without <..>) email returns the key
+    final KeySelectionStrategy sut = new ByEMailKeySelectionStrategy(
+        RFC4880TestKeyringsDedicatedSigningKey.SIGNATURE_KEY_GUARANTEED_EXPIRED_AT);
+
+    assertIsCorrectPublicKey(RFC4880TestKeyringsDedicatedSigningKey.ENCRYPTION_KEY,
+        sut.selectPublicKey(PURPOSE.FOR_ENCRYPTION, "rfc4880@example.org", keyringConfig));
+
+    assertIsCorrectPublicKey(RFC4880TestKeyringsDedicatedSigningKey.SIGNATURE_KEY_ACTIVE,
+        sut.selectPublicKey(PURPOSE.FOR_SIGNING, "rfc4880@example.org", keyringConfig));
+  }
+
+
+  @Test
+  public void searchForEMailQuoted_keyExists_keyIsFound()
+      throws IOException, PGPException {
+
+    // searching for a key based on an quoted (with <..>) email returns the key
+    final KeySelectionStrategy sut = new ByEMailKeySelectionStrategy(
+        RFC4880TestKeyringsDedicatedSigningKey.SIGNATURE_KEY_GUARANTEED_EXPIRED_AT);
+
+    assertIsCorrectPublicKey(RFC4880TestKeyringsDedicatedSigningKey.ENCRYPTION_KEY,
+        sut.selectPublicKey(PURPOSE.FOR_ENCRYPTION, "<rfc4880@example.org>", keyringConfig));
+
+    assertIsCorrectPublicKey(RFC4880TestKeyringsDedicatedSigningKey.SIGNATURE_KEY_ACTIVE,
+        sut.selectPublicKey(PURPOSE.FOR_SIGNING, "<rfc4880@example.org>", keyringConfig));
+  }
+
+
+  @Test
+  public void searchForUserName_keyExists_keyIsNotFound()
+      throws IOException, PGPException {
+
+    // only find the email, not by users name
+    final KeySelectionStrategy sut = new ByEMailKeySelectionStrategy(
+        RFC4880TestKeyringsDedicatedSigningKey.SIGNATURE_KEY_GUARANTEED_EXPIRED_AT);
+
+    assertNull("only find the email, not by users name",
+        sut.selectPublicKey(PURPOSE.FOR_ENCRYPTION, "RFC4880 Test User", keyringConfig));
+
+    assertNull("only find the email, not by users name",
+        sut.selectPublicKey(PURPOSE.FOR_SIGNING, "RFC4880 Test User", keyringConfig));
+  }
+
+
+}

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/RFC4880KeySelectionStrategyQueryStringTest.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/RFC4880KeySelectionStrategyQueryStringTest.java
@@ -1,0 +1,85 @@
+package name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks;
+
+import static name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.KeysTestHelper.assertIsCorrectPublicKey;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import java.security.Security;
+import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.KeySelectionStrategy.PURPOSE;
+import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.KeyringConfig;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openpgp.PGPException;
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * This test complements RFC4880KeySelectionStrategyTest by separating
+ * the query string aspect (analog to ByEMailKeySelectionStrategyTest)
+ */
+public class RFC4880KeySelectionStrategyQueryStringTest {
+
+
+  final KeyringConfig keyringConfig = RFC4880TestKeyringsDedicatedSigningKey
+      .publicAndPrivateKeyKeyringConfig();
+
+  @Before
+  public void before() {
+    if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+      Security.addProvider(new BouncyCastleProvider());
+    }
+  }
+
+
+  private KeySelectionStrategy getSut() {
+    return new Rfc4880KeySelectionStrategy(
+        RFC4880TestKeyringsDedicatedSigningKey.SIGNATURE_KEY_GUARANTEED_EXPIRED_AT);
+  }
+
+
+  @Test
+  public void searchForEMailUnquoted_keyExists_keyIsFound()
+      throws IOException, PGPException {
+
+    // searching for a key based on an unquoted (without <..>) email returns the key
+    final KeySelectionStrategy sut = getSut();
+
+    assertIsCorrectPublicKey(RFC4880TestKeyringsDedicatedSigningKey.ENCRYPTION_KEY,
+        sut.selectPublicKey(PURPOSE.FOR_ENCRYPTION, "rfc4880@example.org", keyringConfig));
+
+    assertIsCorrectPublicKey(RFC4880TestKeyringsDedicatedSigningKey.SIGNATURE_KEY_ACTIVE,
+        sut.selectPublicKey(PURPOSE.FOR_SIGNING, "rfc4880@example.org", keyringConfig));
+  }
+
+
+  @Test
+  public void searchForEMailQuoted_keyExists_keyIsFound()
+      throws IOException, PGPException {
+
+    // searching for a key based on an quoted (with <..>) email returns the key
+    final KeySelectionStrategy sut = getSut();
+
+    assertIsCorrectPublicKey(RFC4880TestKeyringsDedicatedSigningKey.ENCRYPTION_KEY,
+        sut.selectPublicKey(PURPOSE.FOR_ENCRYPTION, "<rfc4880@example.org>", keyringConfig));
+
+    assertIsCorrectPublicKey(RFC4880TestKeyringsDedicatedSigningKey.SIGNATURE_KEY_ACTIVE,
+        sut.selectPublicKey(PURPOSE.FOR_SIGNING, "<rfc4880@example.org>", keyringConfig));
+  }
+
+
+  @Test
+  public void searchForUserName_keyExists_keyIsNotFound()
+      throws IOException, PGPException {
+
+    // only find the email, not by users name
+    final KeySelectionStrategy sut = getSut();
+
+    assertIsCorrectPublicKey(RFC4880TestKeyringsDedicatedSigningKey.ENCRYPTION_KEY,
+        sut.selectPublicKey(PURPOSE.FOR_ENCRYPTION, "RFC4880 Test User", keyringConfig));
+
+    assertIsCorrectPublicKey(RFC4880TestKeyringsDedicatedSigningKey.SIGNATURE_KEY_ACTIVE,
+        sut.selectPublicKey(PURPOSE.FOR_SIGNING, "RFC4880 Test User", keyringConfig));
+  }
+
+
+}

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/RFC4880TestKeyringsDedicatedSigningKey.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/RFC4880TestKeyringsDedicatedSigningKey.java
@@ -354,17 +354,28 @@ ssb  rsa2048/0x83063C3DA3814052
       + "=rT0P\n"
       + "-----END PGP PRIVATE KEY BLOCK-----";
 
-  public static KeyringConfig publicKeyOnlyKeyringConfig() throws IOException, PGPException {
-    final InMemoryKeyring keyring = newKeyring();
-    keyring.addPublicKey(PUBLIC_KEY.getBytes("US-ASCII"));
-    return keyring;
+  public static KeyringConfig publicKeyOnlyKeyringConfig() {
+
+    try {
+      final InMemoryKeyring keyring = newKeyring();
+      keyring.addPublicKey(PUBLIC_KEY.getBytes("US-ASCII"));
+      return keyring;
+    } catch (Exception e) {
+      throw new AssertionError("Failed to initialise test keyring", e);
+
+    }
   }
 
-  public static KeyringConfig publicAndPrivateKeyKeyringConfig() throws IOException, PGPException {
-    final InMemoryKeyring keyring = newKeyring();
-    keyring.addPublicKey(PUBLIC_KEY.getBytes("US-ASCII"));
-    keyring.addSecretKey(PRIVATE_KEY.getBytes("US-ASCII"));
-    return keyring;
+  public static KeyringConfig publicAndPrivateKeyKeyringConfig() {
+    try {
+      final InMemoryKeyring keyring = newKeyring();
+      keyring.addPublicKey(PUBLIC_KEY.getBytes("US-ASCII"));
+      keyring.addSecretKey(PRIVATE_KEY.getBytes("US-ASCII"));
+      return keyring;
+    } catch (Exception e) {
+      throw new AssertionError("Failed to initialise test keyring", e);
+
+    }
   }
 
   private static InMemoryKeyring newKeyring() throws IOException, PGPException {


### PR DESCRIPTION
To enable this new feature call 'selectUidByAnyUidPart()':

```java
   final InputStream plainIS = BouncyGPG.decryptAndVerifyStream()
        .withConfig(Configs.keyringConfigFromFilesForRecipient())
        .selectUidByAnyUidPart()  // << here
        .andRequireSignatureFromAllKeys("Sven Sender")
        ...
```

API CHANGE: Rfc4880KeySelectionStrategy no longer enforces to search
for e-mail only. If you did not use Rfc4880KeySelectionStrategy
directly this will not affect you. ByEMailKeySelectionStrategy provides
the old Rfc4880KeySelectionStrategy behaviour.

Quote from bug report:

> the Rfc4880KeySelectionStrategy's publicKeyRingsForUid() method
> encloses uid queries with < and >, so every query represents an email
> address.
>
> The query juliet@example.org would match the uid
> Juliet Capulet <juliet@example.org>.
>
> Rfc4880 however states:
>
> By convention, it includes an RFC 2822 [RFC2822] mail name-addr, but
> there are no restrictions on its content.
>
> In my case I have to search for uids that do not contain an email
> address (for example xmpp:juliet@example.org).
> As the Rfc4880KeySelectionStrategy encloses all queries with <>, I
> am not able to find those uids.