### PR TITLE
Add OSGI plugin to generate bundle metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 plugins {
     id 'java'
     id 'jacoco'
+    id 'osgi'
 
     id 'checkstyle'
     id 'pmd'


### PR DESCRIPTION
A trivial change to build.gradle to enable the OSGI plugin.
This allows the generation of OSGI bundle metadata in the resulting jar file, which in turn resolves classloader issues when running bouncy-gpg in OSGI environments.