### PR TITLE
Apply bnd plugin to generate OSGI bundle metadata

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,1 @@
+Export-Package: name.neuhalfen.projects.crypto.bouncycastle.openpgp.*

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@ buildscript {
     repositories {
         jcenter()
     }
+    dependencies {
+        classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:4.1.0'
+    }
 }
 
 plugins {
@@ -133,3 +136,6 @@ apply from: 'website.gradle'
 wrapper{
     gradleVersion = '4.10.2'
 }
+
+// Generate OSGI bundle metadata
+apply plugin: 'biz.aQute.bnd.builder'


### PR DESCRIPTION
A trivial change to enable/configure the BND plugin.
This allows the generation of OSGI bundle metadata in the resulting jar file, which in turn resolves classloader issues when running bouncy-gpg in OSGI environments.