### PR TITLE
fixed message at successful validated signature

### DIFF
--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/validation/SignatureValidationHelper.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/validation/SignatureValidationHelper.java
@@ -30,7 +30,7 @@ final class SignatureValidationHelper {
 
         if (isThisSignatureGood) {
           LOGGER.debug(
-              "Successful validated signature with key 0x{} because we have no matching public key",
+              "Successful validated signature with key 0x{}",
               Long.toHexString(messageSignature.getKeyID()));
           goodSignatures.add(messageSignature.getKeyID());
         }


### PR DESCRIPTION
If "Successful validated signature" is true, there should be no "because we have no matching public key".
See: https://github.com/neuhalje/bouncy-gpg/blob/f11eae65068afd94dd5eccbdb0cd1bb8ab5f5f0b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/validation/SignatureValidationHelper.java#L33

I was very confused because I always get that message:

Actual:
> DEBUG name.neuhalfen.projects.crypto.bouncycastle.openpgp.validation.SignatureValidationHelper - Successful validated signature with key 0x... because we have no matching public key

First it has looked like an optional signature evaluation.

Expected:
> DEBUG name.neuhalfen.projects.crypto.bouncycastle.openpgp.validation.SignatureValidationHelper - Successful validated signature with key 0x...

Seems to be a copy of https://github.com/neuhalje/bouncy-gpg/blob/f11eae65068afd94dd5eccbdb0cd1bb8ab5f5f0b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/validation/SignatureValidationHelper.java#L39
