### PR TITLE
Allow skip in SignatureValidatingInputStream

### DIFF
--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/decrypting/SignatureValidatingInputStream.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/decrypting/SignatureValidatingInputStream.java
@@ -85,11 +85,6 @@ final class SignatureValidatingInputStream extends FilterInputStream {
 
   }
 
-  @Override
-  public long skip(long n) throws IOException {
-    throw new UnsupportedOperationException("Skipping not supported");
-  }
-
   @SuppressWarnings("PMD.AvoidSynchronizedAtMethodLevel")
   @Override
   public synchronized void mark(int readlimit) {


### PR DESCRIPTION
InputStream has a default implementation of skip() that just reads byte by byte. It's not particularly efficient but will work. I want to read a tar archive from a SignatureValidatingInputStream, and the library will call skip() to gloss over directory entries.

With the current implementation I have to write the whole stream to a file on storage, unarchive it and then delete it again.

BTW hard to say how much headache you saved me from with this library, deeply appreciated. BC is arcane.