### PR TITLE
fix #46 by reverting 012c3f9

### DIFF
--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/decrypting/DecryptionStreamFactory.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/decrypting/DecryptionStreamFactory.java
@@ -154,17 +154,11 @@ public final class DecryptionStreamFactory {
         }
 
         // decrypt the data
-
-        try(
-                InputStream plainText = pbe
-            .getDataStream(new BcPublicKeyDataDecryptorFactory(
-                privateKey)) // NOPMD: AvoidInstantiatingObjectsInLoops
-        )
-        {
-          final PGPObjectFactory nextFactory = new PGPObjectFactory(plainText,
-                  new BcKeyFingerprintCalculator());// NOPMD: AvoidInstantiatingObjectsInLoops
-          return nextDecryptedStream(nextFactory, state);  // NOPMD: OnlyOneReturn
-        }
+        final InputStream plainText = pbe
+            .getDataStream(new BcPublicKeyDataDecryptorFactory(privateKey)); // NOPMD: AvoidInstantiatingObjectsInLoops
+        final PGPObjectFactory nextFactory = new PGPObjectFactory(plainText,
+            new BcKeyFingerprintCalculator());// NOPMD: AvoidInstantiatingObjectsInLoops
+        return nextDecryptedStream(nextFactory, state);  // NOPMD: OnlyOneReturn
       } else if (pgpObj instanceof PGPCompressedData) {
         LOGGER.trace("Found instance of PGPCompressedData");
         final PGPObjectFactory nextFactory = new PGPObjectFactory(


### PR DESCRIPTION
that commit did not make sense, as we should not close a stream that is going to be wrapped by additional streams, which haven't even been created yet; instead the wrapping streams should be responsible for closing the streams they wrap once they are fully done with them; all tests pass