### PR TITLE
Fix for issue 50, encrypting with keys that don't have a KeyFlags subpacket

### DIFF
--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/generation/KeyFlag.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/generation/KeyFlag.java
@@ -94,6 +94,12 @@ public enum KeyFlag {
     return flags;
   }
 
+  /**
+   * Returns the list of key flags (ie whether the key can be used to encrypt, sign, etc) based on the analysis of the
+   * KeyFlags subpacket. Returns an empty Optional object if the key does not contain a KeyFlags subpacket
+   * @param publicKey the key to analyse
+   * @return a list of key flags, or an empty Optional if the key doesn't contain a KeyFlags subpacket
+   */
   @SuppressWarnings({"PMD.LawOfDemeter"})
   public static Optional<Set<KeyFlag>> extractPublicKeyFlags(PGPPublicKey publicKey) {
     requireNonNull(publicKey, "publicKey must not be null");

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/encrypting/EncryptionScenariosTest.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/encrypting/EncryptionScenariosTest.java
@@ -2,11 +2,8 @@ package name.neuhalfen.projects.crypto.bouncycastle.openpgp.encrypting;
 
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.BouncyGPG;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.algorithms.DefaultPGPAlgorithmSuites;
-import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.callbacks.KeyringConfigCallbacks;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.InMemoryKeyring;
-import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.KeyringConfig;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.KeyringConfigs;
-import name.neuhalfen.projects.crypto.bouncycastle.openpgp.testtooling.Configs;
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.testtooling.ExampleMessages;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.util.io.Streams;
@@ -19,6 +16,7 @@ import java.security.SignatureException;
 import java.time.Instant;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests several encryption scenarios. As usual, most are integration style tests.
@@ -75,4 +73,47 @@ public class EncryptionScenariosTest {
         assertArrayEquals(ExampleMessages.IMPORTANT_QUOTE_TEXT.getBytes(), plainBA.toByteArray());
     }
 
+    @Test
+    public void encrypt_masterKeyWithoutSubkeysOrKeyFlags_works()
+            throws IOException, PGPException, NoSuchAlgorithmException, SignatureException, NoSuchProviderException {
+
+        // Reported in  https://github.com/neuhalje/bouncy-gpg/issues/50
+
+        /* We test that a key that doesn't contain any KeyFlags subpacket can still be used for encrypting,
+        by checking the key algorithm, like GPG does
+         */
+
+        // keyring
+        InMemoryKeyring sendersKeyring = KeyringConfigs.forGpgExportedKeys(keyId -> null);
+        sendersKeyring.addPublicKey(ExampleMessages.ONLY_MASTER_KEY_PUBKEY_NO_KEY_FLAGS.getBytes());
+
+        // encrypt
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(result);
+
+        final OutputStream outputStream = BouncyGPG
+                .encryptToStream()
+                .withConfig(sendersKeyring)
+                .setReferenceDateForKeyValidityTo(Instant.MAX)
+                .withAlgorithms(DefaultPGPAlgorithmSuites.strongSuite())
+                .toRecipient(ExampleMessages.ONLY_MASTER_KEY_UID_NO_KEY_FLAGS)
+                .andDoNotSign()
+                .binaryOutput()
+                .andWriteTo(bufferedOutputStream);
+
+        final InputStream is = new ByteArrayInputStream(
+                ExampleMessages.IMPORTANT_QUOTE_TEXT.getBytes());
+        Streams.pipeAll(is, outputStream);
+        outputStream.close();
+        bufferedOutputStream.close();
+        is.close();
+
+        /* test that the data can be encrypted.
+           If the test fails, Bouncy-PGP would complain that it can't find a public key to encrypt with
+         */
+
+        final byte[] ciphertext = result.toByteArray();
+        result.close();
+        assertNotNull(ciphertext);
+    }
 }

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/testtooling/ExampleMessages.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/testtooling/ExampleMessages.java
@@ -483,6 +483,34 @@ public class ExampleMessages {
           "=8wl4\n" +
           "-----END PGP PRIVATE KEY BLOCK-----\n";
 
+  public final static long ONLY_MASTER_KEY_ID_NO_KEY_FLAGS = 0x9E698FBA9F857349L;
+  public final static String ONLY_MASTER_KEY_UID_NO_KEY_FLAGS = "support@anzgcis.com";
+  public final static String ONLY_MASTER_KEY_PASSPHRASE_NO_KEY_FLAGS = "";
+  public final static String ONLY_MASTER_KEY_PUBKEY_NO_KEY_FLAGS= "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+          "Version: SecureBlackbox 15\n" +
+          "\n" +
+          "xsBNBFtrhAABCACbJgPWFmodLq0cqIwiZG8hnHusSBA1nan8OQk2Dr+l37smSjO7\n" +
+          "TT0N/G8er79lgVyynYXXHH7EfY7tvvWPS5N55NvYiLxRYRPgFgy+cD6TsSn8W0qD\n" +
+          "zwCf5Jw5ZeU4pdRo6hN1Qgl6IcETQWZOsob3BWmg2aLnl+1SyY3zh0jW6z6Wn4En\n" +
+          "tpPj4iELe6o1SNcmC2A2fIVUoMlBHa+Mcumw+kqv4vsA6xJmpDYniBaW/asVaIBl\n" +
+          "4bA0Iux5Osr83pNJOBHpLk9ozyMF0rtqyyvA8l3SiLA2jyeXoBEQ9mEJi+G0/PBI\n" +
+          "mAoMs3FXlu4Dqdh6jk0vHDk261tMq8wqas7nABEBAAHCwGIEHwEIABYFCRLMAwAF\n" +
+          "AltreqYJEJ5pj7qfhXNJAACwjQgAktbLedTzTJmRgdgQsH3uakoFmi7Pc2Q/N9J7\n" +
+          "q8wJhBcxUUILQQck9fmzM4XOgAJmX0Sn+3xnkUvdnSP8EGd5SPezoDo29Udrm99z\n" +
+          "LV//9N5p4febzQwAhQJg3rGz5oDt5VMwTdSxhxPAKvkIV1QAQFqeZn6wO26Voz3h\n" +
+          "wfLt3xX904pomtCeakdRu+akqTBKS28Q6atHauHAAzlr1cfjLcLHdqI1y1zUbAyE\n" +
+          "dmYhpiIM3sr1ZvjaSRQv+vF/l5z88EVE5Ag4U5Mdw8X7R9WCnEk5ojOOveNYIsq2\n" +
+          "rjh9rAvD6aNBK4v+1wx9P1zSv227SojxX+AB103GSYitBSLTUs0oRmlsZWFjdGl2\n" +
+          "ZSBTdXBwb3J0IDxzdXBwb3J0QGFuemdjaXMuY29tPsLAXwQQAQgAEwUCW2wHRgIZ\n" +
+          "AQkQnmmPup+Fc0kAAGN8CACR82NV7nMGOm/crnu7k2dCHCoiTsucerG1tDFyCNYx\n" +
+          "3w0WATvSBS6XRwLfl6IaVbjpauZk+bH6NVgo9tpwKwGn7Wh9takHMsuRPoNiudqf\n" +
+          "S/duYt/ugOhlajfe3EFuGlt62j8pVT5o9bgCZQNEUgkGzwwz+j/saWHsI9fW26Ri\n" +
+          "W/tyJk0IICLf2aEJOi63PsllRQ+CtimvZkRalvcCuS19JNcYZlz3GyM/+z3LiYMi\n" +
+          "b1s+vDO4ZJgka+nTWHL1VrbctH79n23hmV1pK7LXAl8mZlo0wUU+R+01WumSVSQZ\n" +
+          "XGs5vAe6nG216ghBcNNd0UbQMZXwuIQlOtN5CSwoHdp6\n" +
+          "=qWOE\n" +
+          "-----END PGP PUBLIC KEY BLOCK-----\n";
+
   public final static Map<Long, char[]> ALL_KEYRINGS_PASSWORDS = BUILD_ALL_KEYRINGS_PASSWORDS();
   /**
    * Encrypted-To:    recipient@example.com Signed-By:       sender@example.com Compressed: false
@@ -738,6 +766,7 @@ public class ExampleMessages {
     m.put(ExampleMessages.PUBKEY_ID_RECIPIENT, "recipient".toCharArray());
 
     m.put(ExampleMessages.ONLY_MASTER_KEY_ID, null);
+    m.put(ExampleMessages.ONLY_MASTER_KEY_ID_NO_KEY_FLAGS, null);
     return Collections.unmodifiableMap(m);
   }
 

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/testtooling/matcher/SecretKeyringKeyRoleMatcher.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/testtooling/matcher/SecretKeyringKeyRoleMatcher.java
@@ -1,9 +1,7 @@
 package name.neuhalfen.projects.crypto.bouncycastle.openpgp.testtooling.matcher;
 
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.Set;
+import java.util.*;
+
 import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.generation.KeyFlag;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPSecretKey;
@@ -54,21 +52,22 @@ public class SecretKeyringKeyRoleMatcher extends TypeSafeMatcher<PGPSecretKeyRin
   EnumSet<KeyRole> parseKey(final PGPSecretKey item) {
     final EnumSet<KeyRole> found = EnumSet.noneOf(KeyRole.class);
     final PGPPublicKey publicKey = item.getPublicKey();
-    final Set<KeyFlag> keyFlags = KeyFlag.extractPublicKeyFlags(publicKey);
+    final Optional<Set<KeyFlag>> keyFlags = KeyFlag.extractPublicKeyFlags(publicKey);
 
     if (item.isMasterKey()) {
       found.add(KeyRole.MASTER);
     }
 
     if (item.isSigningKey()) {
-      if (keyFlags.contains(KeyFlag.SIGN_DATA)) {
+      if (keyFlags.isPresent() && keyFlags.get().contains(KeyFlag.SIGN_DATA)) {
         found.add(KeyRole.SIGNING);
       }
     }
 
     if (item.getPublicKey().isEncryptionKey()) {
       final boolean hasEncryptionFlags =
-          keyFlags.contains(KeyFlag.ENCRYPT_STORAGE) || keyFlags.contains(KeyFlag.ENCRYPT_COMMS);
+              keyFlags.isPresent() && keyFlags.get().contains(KeyFlag.ENCRYPT_STORAGE) ||
+                      keyFlags.isPresent() && keyFlags.get().contains(KeyFlag.ENCRYPT_COMMS);
       if (hasEncryptionFlags) {
         found.add(KeyRole.ENCRYPTION);
       }


### PR DESCRIPTION
The current code checks the KeyFlags subpacket to determine if a key can be used to encrypt/sign.
However if the key doesn't have a KeyFlags subpacket Bouncy-GPG refuses to use it to encrypt/sign, whereas GPG has a fallback scenario where it analyses the key's algorithm to determine its role.

We implemented the same fallback scenario here, using the key algorithm if it doesn't have a KeyFlags subpacket.