### PR TITLE
Fix double verification error #66

### DIFF
--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/decrypting/MDCValidatingInputStream.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/decrypting/MDCValidatingInputStream.java
@@ -13,6 +13,10 @@ final class MDCValidatingInputStream extends FilterInputStream {
   private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory
       .getLogger(MDCValidatingInputStream.class);
 
+  private final PGPPublicKeyEncryptedData pbe;
+
+  private boolean mdcChecked;
+
   /**
    * Creates a <code>MDCValidatingInputStream</code> by assigning the  argument
    * <code>inputStream</code> to the field <code>this.inputStream</code> and <code>pbe</code> to <code>this.pbe</code> so as to remember it for
@@ -21,9 +25,6 @@ final class MDCValidatingInputStream extends FilterInputStream {
    * @param inputStream the underlying input stream
    * @param pbe the pgp public key encrypted data to verify message integrity
    */
-
-  private final PGPPublicKeyEncryptedData pbe;
-
   MDCValidatingInputStream(InputStream inputStream, PGPPublicKeyEncryptedData pbe) {
     super(inputStream);
     this.pbe = pbe;
@@ -61,6 +62,11 @@ final class MDCValidatingInputStream extends FilterInputStream {
    * @throws IOException Error while reading input stream or if MDC fails
    */
   private void validateMDC() throws IOException {
+    if (mdcChecked) {
+      return;
+    }
+    mdcChecked = true;
+
     try {
       if (pbe.isIntegrityProtected()) {
         if (!pbe.verify()) {


### PR DESCRIPTION
Fixes #66 

Nesting inputstreams can result in a child stream reaching its end twice.
For the MDCValidatingInputStream this results in verifying the MDC twice.
PGPEncryptedData#verify doesn't handle being called twice.

`decryptNoSignatureValidation_withWrapperStream_works` fails without the fix in MDCValidatingInputStream.

Fix with a simple boolean flag to prevent double verification.
Another alternative option would be making a change to PGPEncryptedData#verify.
