### PR TITLE
Allow setting name and modification date for literal data packet; BC …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## V 2.x.x (NEXT)
 
+* Enh: Bump Bouncy Castle to 1.77 and jdk18on for security fixes
+* New: Provide a way to change name and modification date in literal data packet
+
 ## V 2.3.0 Bugfix Release
 
 This releases fixes a security issue (#50) where encrypted, but not signed archives could be modified. 

--- a/build.gradle
+++ b/build.gradle
@@ -123,8 +123,8 @@ check.dependsOn integrationTest
 
 
 dependencies {
-    compile 'org.bouncycastle:bcprov-jdk15on:1.67'
-    compile 'org.bouncycastle:bcpg-jdk15on:1.67'
+    compile 'org.bouncycastle:bcprov-jdk18on:1.77'
+    compile 'org.bouncycastle:bcpg-jdk18on:1.77'
 
     compile 'org.slf4j:slf4j-api:1.7.30'
 

--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/BuildEncryptionOutputStreamAPI.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/BuildEncryptionOutputStreamAPI.java
@@ -52,6 +52,9 @@ public final class BuildEncryptionOutputStreamAPI {
   private Set<PGPPublicKey> recipients;
   private boolean armorOutput;
 
+  private NameProvider nameProvider;
+  private ModificationDateProvider modificationDateProvider;
+
   // Signature
 
 
@@ -94,6 +97,21 @@ public final class BuildEncryptionOutputStreamAPI {
 
 
   public interface Build {
+
+    /**
+     * Set name a modification date providers which will be used to set name and modification date
+     * of literal data (literal packet in the output data).
+     * <p/>
+     * This allows acts like we are actually working with a file, not just unnamed, just-in-time stream of data.
+     * <p/>
+     * If not provided ({@code null}), default values will be used - empty string ({@code ""}) as a name
+     * anc current date ({@code new Date()}) as a modification date.
+     *
+     * @param nameProvider literal data name provider (nullable)
+     * @param modificationDateProvider literal data modification date provider (nullable)
+     * @return this
+     */
+    Build withProviders(NameProvider nameProvider, ModificationDateProvider modificationDateProvider);
 
     OutputStream andWriteTo(OutputStream sinkForEncryptedData)
         throws PGPException, SignatureException, NoSuchAlgorithmException, NoSuchProviderException, IOException;
@@ -503,6 +521,13 @@ public final class BuildEncryptionOutputStreamAPI {
           public final class Builder implements Build {
 
             @Override
+            public Build withProviders(NameProvider nameProvider, ModificationDateProvider modificationDateProvider) {
+              BuildEncryptionOutputStreamAPI.this.nameProvider = nameProvider;
+              BuildEncryptionOutputStreamAPI.this.modificationDateProvider = modificationDateProvider;
+              return this;
+            }
+
+            @Override
             public OutputStream andWriteTo(OutputStream sinkForEncryptedData)
                 throws PGPException, SignatureException, NoSuchAlgorithmException, NoSuchProviderException, IOException {
               BuildEncryptionOutputStreamAPI.this.sinkForEncryptedData = sinkForEncryptedData;
@@ -513,7 +538,9 @@ public final class BuildEncryptionOutputStreamAPI {
                   BuildEncryptionOutputStreamAPI.this.sinkForEncryptedData,
                   getKeySelectionStrategy(),
                   BuildEncryptionOutputStreamAPI.this.armorOutput,
-                  BuildEncryptionOutputStreamAPI.this.recipients);
+                  BuildEncryptionOutputStreamAPI.this.recipients,
+                  BuildEncryptionOutputStreamAPI.this.nameProvider,
+                  BuildEncryptionOutputStreamAPI.this.modificationDateProvider);
 
             }
           }

--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/ModificationDateProvider.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/ModificationDateProvider.java
@@ -1,0 +1,24 @@
+package name.neuhalfen.projects.crypto.bouncycastle.openpgp;
+
+import java.io.OutputStream;
+import java.util.Date;
+
+/**
+ * Modification date provider.
+ *
+ * @see org.bouncycastle.openpgp.PGPLiteralDataGenerator#open(OutputStream, char, String, Date, byte[])
+ */
+public interface ModificationDateProvider {
+
+    /**
+     * Default instance which provides modification date as a current date.
+     */
+    ModificationDateProvider DEFAULT_INSTANCE = Date::new;
+
+    /**
+     * Provide desired modification date.
+     *
+     * @return modification date (<b>never {@code null}</b>)
+     */
+    Date getModificationDate();
+}

--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/NameProvider.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/NameProvider.java
@@ -1,0 +1,26 @@
+package name.neuhalfen.projects.crypto.bouncycastle.openpgp;
+
+import java.io.OutputStream;
+import java.util.Date;
+
+/**
+ * Name provider.
+ *
+ * @see org.bouncycastle.openpgp.PGPLiteralDataGenerator#open(OutputStream, char, String, Date, byte[])
+ */
+public interface NameProvider {
+
+    /**
+     * Default instance which provides an empty string ({@code ""}) as a name.
+     */
+    NameProvider DEFAULT_INSTANCE = () -> "";
+
+    /**
+     * Provide desired name.
+     *
+     * @return name (never <b>never {@code null}</b>)
+     */
+    String getName();
+}
+
+

--- a/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/Rfc4880KeySelectionStrategy.java
+++ b/src/main/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/keys/callbacks/Rfc4880KeySelectionStrategy.java
@@ -182,21 +182,14 @@ public class Rfc4880KeySelectionStrategy implements KeySelectionStrategy {
     return pubKey -> {
       requireNonNull(pubKey, "pubKey must not be null");
 
-      try {
-        final boolean hasPrivateKey = secretKeyRings.contains(pubKey.getKeyID());
+      final boolean hasPrivateKey = secretKeyRings.contains(pubKey.getKeyID());
 
-        if (!hasPrivateKey) {
-          LOGGER.trace("Skipping pubkey {} (no private key found)",
-              Long.toHexString(pubKey.getKeyID()));
-        }
-
-        return hasPrivateKey;
-      } catch (PGPException e) {
-        // ignore this for filtering
-        LOGGER.debug("Failed to test for private key for pubkey " + pubKey//NOPMD:GuardLogStatement
-            .getKeyID());
-        return false;
+      if (!hasPrivateKey) {
+        LOGGER.trace("Skipping pubkey {} (no private key found)",
+            Long.toHexString(pubKey.getKeyID()));
       }
+
+      return hasPrivateKey;
     };
   }
 

--- a/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/encrypting/PGPEncryptingStreamTest.java
+++ b/src/test/java/name/neuhalfen/projects/crypto/bouncycastle/openpgp/encrypting/PGPEncryptingStreamTest.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SignatureException;


### PR DESCRIPTION
BC 1.77 and jdk8on:
* since BC jdk15on stopped with version 1.67 and there are still vulnerabilities, moved to jdk18on
* source and target compatibility is set to Java 8 anyway
* updated to latest version

New providers:
* in some cases, we need to set a name and/or modification date for a literal data packet in encrypted/signed file. This library is designed to work with stream, yet we can stream a file content...
* ... or, we can simulate file or need to set for whatever reason name of literal data
* this PR has two new functional interfaces to provide name and/or modification date
* default is to use current behavior (an empty string as a name `""` and current date `new Date()` as a modification date)
* implemented in `Build` interface